### PR TITLE
Allow for different count functions in admin

### DIFF
--- a/data/generator/sfDoctrineModule/ua5_2/parts/paginationAction.php
+++ b/data/generator/sfDoctrineModule/ua5_2/parts/paginationAction.php
@@ -3,8 +3,15 @@
     $pager = $this->configuration->getPager('<?php echo $this->getModelClass() ?>');
     $pager->setQuery($this->buildQuery());
     $pager->setPage($this->getPage());
-    $pager->init();
 
+    $tableCountMethod = $this->configuration->getTableCountMethod();
+    $table = Doctrine_Core::getTable('<?php echo $this->getModelClass() ?>');
+    if ('' !== $tableCountMethod && method_exists($table, $tableCountMethod)) {
+        $query = $table->createQuery('a');
+        $countQuery = $table->$tableCountMethod($query);
+        $pager->setCountQuery($countQuery);
+    }
+    $pager->init();
     return $pager;
   }
 

--- a/data/generator/sfDoctrineModule/ua5_2/parts/paginationConfiguration.php
+++ b/data/generator/sfDoctrineModule/ua5_2/parts/paginationConfiguration.php
@@ -1,6 +1,6 @@
   public function getPagerClass()
   {
-    return '<?php echo isset($this->config['list']['pager_class']) ? $this->config['list']['pager_class'] : 'sfDoctrinePager' ?>';
+    return '<?php echo isset($this->config['list']['pager_class']) ? $this->config['list']['pager_class'] : 'ua5DoctrinePager' ?>';
 <?php unset($this->config['list']['pager_class']) ?>
   }
 
@@ -9,3 +9,5 @@
     return <?php echo isset($this->config['list']['max_per_page']) ? (integer) $this->config['list']['max_per_page'] : 20 ?>;
 <?php unset($this->config['list']['max_per_page']) ?>
   }
+
+

--- a/lib/pager/ua5DoctrinePager.class.php
+++ b/lib/pager/ua5DoctrinePager.class.php
@@ -1,0 +1,27 @@
+<?php
+
+class ua5DoctrinePager extends sfDoctrinePager
+{
+  protected $queryCountFunction = null;
+
+  public function getCountQuery()
+  {
+    if (isset(null !== $this->queryCountFunction)) {
+      $query = $this->queryCountFunction;
+    } else {
+      $query = clone $this->getQuery();
+    }
+
+    $query
+      ->offset(0)
+      ->limit(0)
+    ;
+
+    return $query;
+  }
+
+  public function setCountQuery($query)
+  {
+    $this->queryCountFunction = $query;
+  }
+}


### PR DESCRIPTION
Allow for a table_count_function in the list section of the generator config. If the method
is defined on the table, it will override the default count function and use your custom
function instead.

```
generator:
  param:
    config:
      list:
        table_count_method: customMethod
```

closes UseAllFive/Kneon#68
